### PR TITLE
Created Test for Private Posts

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -159,6 +159,15 @@ describe('Post\'s', () => {
             assert.equal(postData, null);
             done();
         });
+
+    it('should update typeOfPost from public to private', async () => {
+        const testUser = await user.create({ username: 'Gogogojo' });
+        const post = await posts.create({ uid: testUser, cid: cid, title: 'Test Title', content: 'This is a test post.', typeOfPost:"private"});
+        const pid = post.pid;
+        const res = await posts.getPostData(pid);
+        assert.equal(res.typeOfPost,"private");
+        });
+
     });
 
     describe('voting', () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -159,15 +159,14 @@ describe('Post\'s', () => {
             assert.equal(postData, null);
             done();
         });
+    });
 
     it('should update typeOfPost from public to private', async () => {
         const testUser = await user.create({ username: 'Gogogojo' });
-        const post = await posts.create({ uid: testUser, cid: cid, title: 'Test Title', content: 'This is a test post.', typeOfPost:"private"});
-        const pid = post.pid;
+        const post = await posts.create({ uid: testUser, cid: cid, title: 'Test Title', content: 'This is a test post.', typeOfPost: 'private' });
+        const { pid } = post.pid;
         const res = await posts.getPostData(pid);
-        assert.equal(res.typeOfPost,"private");
-        });
-
+        assert.equal(res.typeOfPost, 'private');
     });
 
     describe('voting', () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -164,7 +164,7 @@ describe('Post\'s', () => {
     it('should update typeOfPost from public to private', async () => {
         const testUser = await user.create({ username: 'Gogogojo' });
         const post = await posts.create({ uid: testUser, cid: cid, title: 'Test Title', content: 'This is a test post.', typeOfPost: 'private' });
-        const { pid } = post.pid;
+        const { pid } = post;
         const res = await posts.getPostData(pid);
         assert.equal(res.typeOfPost, 'private');
     });


### PR DESCRIPTION
Resolves #46 

Created a test to check if the post attribute `typeOfPost` is set to 'private' when the user checks the box to make a post private before submitting.