### PR TITLE
Added a Test Case for Resolving a Post

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -412,6 +412,15 @@ describe('Topic\'s', () => {
             });
         });
 
+        // added a test case for resolving a post
+        it('should get the resolve attribute of a post [thats resolved]', (done) => {
+            topics.getTopicFields(newTopic.tid, ['isResolved'], (err, data) => {
+                assert.ifError(err);
+                assert(data.hasOwnProperty('isResolved'));
+                done();
+            });
+        });
+
         describe('.getTopicWithPosts', () => {
             let tid;
             before(async () => {


### PR DESCRIPTION
Resolves #47 

I have created a test to verify that the `isResolved` attribute of the topic is set to `true` when a user clicks the `resolve`'button after the post has been created.

File: _test/topics.js_