### PR TITLE
updated template for Anonmity

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -19,7 +19,7 @@ module.exports = function (Topics) {
     Topics.create = async function (data) {
         // This is an internal method, consider using Topics.post instead
         const timestamp = data.timestamp || Date.now();
-
+        const isAnonymous = String(data.isAnonymous);
         const tid = await db.incrObjectField('global', 'nextTid');
 
         let topicData = {
@@ -35,6 +35,8 @@ module.exports = function (Topics) {
             viewcount: 0,
             // added attribute for resolved --maria
             isResolved: false,
+            // added attribute for anonymous --rama
+            isAnonymous: isAnonymous,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -144,6 +144,12 @@ Topics.getTopicsByTids = async function (tids, options) {
             topic.unreplied = !topic.teaser;
 
             topic.icons = [];
+            topic.displayname = topic.user.displayname;
+            topic.userslug = topic.user.userslug;
+            if (topic.isAnonymous === 'anonymous') {
+                topic.displayname = 'anonymous';
+                topic.userslug = 'anonymous';
+            }
         }
     });
 

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -69,6 +69,8 @@ export type TopicSlimProperties = {
   thumbs: Thumb[];
   visibilityType: string;
   isAnonymous: string;
+  displayname: string;
+  userslug: string;
 };
 
 export type Thumb = {

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -60,7 +60,7 @@
                 </span>
                 {{{ end }}}
 
-                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a></small>
+                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.displayname}</a></small>
                 <small class="visible-xs-inline">
                     <!-- IF topics.teaser.timestamp -->
                     <span class="timeago" title="{topics.teaser.timestampISO}"></span>


### PR DESCRIPTION
resolved #30 

In order to reflect the anonymity feature in the Q&A topic list page, two string attributes were added to the topic object (userslug and displayname which already exists for the user but not for a topic object). This is because the topics_list.tpl is using the user information to display the name and profile link. However since we want a user to be able to post both types of posts anonymous and not anonymous then a new attribute was added (types/topic.ts), updates in (src/topics/create.js and index.js), and displayed on (themes/nodebb-theme-persona/templates/partials/topics_list.tpl)